### PR TITLE
Remove icon suffix from generated components

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ const main = () => {
 
     // Work with files
     const svg = fs.readFileSync(`./${file}`, { encoding: "utf-8" });
-    const componentName = `${capitalize(path.basename(file, ".svg").trim())}Icon`;
+    const componentName = capitalize(path.basename(file, ".svg").trim());
     const pathFileToMin = `${outPath}/${componentName}.js`;
 
     const payload = {


### PR DESCRIPTION
This generator can be used for more than icons, so it would be great if the generated component name is just based on the original file name (without having `'Icon'` appended to it). If someone wants that ending, they could just rename the image file.

If you still want this functionality, another way to do it would be to add a `--suffix` CLI argument. I can make that change as well.